### PR TITLE
ADLMIDI, EDMIDI, OPNMIDI: use GNU90 standard

### DIFF
--- a/libADLMIDI/CMakeLists.txt
+++ b/libADLMIDI/CMakeLists.txt
@@ -132,7 +132,7 @@ function(set_legacy_standard destTarget)
     if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
         # Turn on warnings and legacy C/C++ standards to support more compilers
         target_compile_options(${destTarget} PRIVATE
-            $<$<COMPILE_LANGUAGE:C>:-Wall -pedantic -std=c90 -Wno-long-long>
+            $<$<COMPILE_LANGUAGE:C>:-Wall -pedantic -std=gnu90 -Wno-long-long>
             $<$<COMPILE_LANGUAGE:CXX>:-Wall -pedantic -std=gnu++98>
         )
     endif()

--- a/libEDMIDI/CMakeLists.txt
+++ b/libEDMIDI/CMakeLists.txt
@@ -61,7 +61,7 @@ function(set_legacy_standard destTarget)
     if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
         # Turn on warnings and legacy C/C++ standards to support more compilers
         target_compile_options(${destTarget} PRIVATE
-            $<$<COMPILE_LANGUAGE:C>:-Wall -pedantic -std=c90 -Wno-long-long>
+            $<$<COMPILE_LANGUAGE:C>:-Wall -pedantic -std=gnu90 -Wno-long-long>
             $<$<COMPILE_LANGUAGE:CXX>:-Wall -pedantic -std=gnu++98>
         )
     endif()

--- a/libOPNMIDI/CMakeLists.txt
+++ b/libOPNMIDI/CMakeLists.txt
@@ -121,7 +121,7 @@ function(set_legacy_standard destTarget)
     if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
         # Turn on warnings and legacy C/C++ standards to support more compilers
         target_compile_options(${destTarget} PRIVATE
-            $<$<COMPILE_LANGUAGE:C>:-Wall -pedantic -std=c90>
+            $<$<COMPILE_LANGUAGE:C>:-Wall -pedantic -std=gnu90>
             $<$<COMPILE_LANGUAGE:CXX>:-Wall -pedantic -std=gnu++98>
         )
     endif()


### PR DESCRIPTION
Fixes 3DS build on some versions of devkitPro toolchain