### PR TITLE
SDL2 - 3DS fixes

### DIFF
--- a/SDL2/src/audio/SDL_audio.c
+++ b/SDL2/src/audio/SDL_audio.c
@@ -1261,7 +1261,9 @@ static SDL_AudioDeviceID open_audio_device(const char *devname, int iscapture,
                                            const SDL_AudioSpec *desired, SDL_AudioSpec *obtained,
                                            int allowed_changes, int min_id)
 {
+#ifndef __3DS__
     const SDL_bool is_internal_thread = (desired->callback == NULL);
+#endif
     SDL_AudioDeviceID id = 0;
     SDL_AudioSpec _obtained;
     SDL_AudioDevice *device;
@@ -1502,7 +1504,11 @@ static SDL_AudioDeviceID open_audio_device(const char *devname, int iscapture,
         /* Start the audio thread */
         /* !!! FIXME: we don't force the audio thread stack size here if it calls into user code, but maybe we should? */
         /* buffer queueing callback only needs a few bytes, so make the stack tiny. */
+#ifdef __3DS__
+        const size_t stacksize = 64 * 1024;
+#else
         const size_t stacksize = is_internal_thread ? 64 * 1024 : 0;
+#endif
         char threadname[64];
 
         (void)SDL_snprintf(threadname, sizeof(threadname), "SDLAudio%c%" SDL_PRIu32, (iscapture) ? 'C' : 'P', device->id);

--- a/SDL2/src/audio/n3ds/SDL_n3dsaudio.c
+++ b/SDL2/src/audio/n3ds/SDL_n3dsaudio.c
@@ -246,7 +246,7 @@ static void N3DSAUDIO_CloseDevice(_THIS)
 
 static void N3DSAUDIO_ThreadInit(_THIS)
 {
-    s32 current_priority;
+    s32 current_priority = 0x30;
     svcGetThreadPriority(&current_priority, CUR_THREAD_HANDLE);
     current_priority--;
     /* 0x18 is reserved for video, 0x30 is the default for main thread */

--- a/SDL2/src/audio/n3ds/SDL_n3dsaudio.c
+++ b/SDL2/src/audio/n3ds/SDL_n3dsaudio.c
@@ -38,6 +38,7 @@ static SDL_AudioDevice *audio_device;
 static void FreePrivateData(_THIS);
 static int FindAudioFormat(_THIS);
 
+// fully local functions related to the wavebufs / DSP, not the same as the SDL-wide mixer lock
 static SDL_INLINE void contextLock(_THIS)
 {
     LightLock_Lock(&this->hidden->lock);
@@ -46,16 +47,6 @@ static SDL_INLINE void contextLock(_THIS)
 static SDL_INLINE void contextUnlock(_THIS)
 {
     LightLock_Unlock(&this->hidden->lock);
-}
-
-static void N3DSAUD_LockAudio(_THIS)
-{
-    contextLock(this);
-}
-
-static void N3DSAUD_UnlockAudio(_THIS)
-{
-    contextUnlock(this);
 }
 
 static void N3DSAUD_DspHook(DSP_HookType hook)
@@ -195,6 +186,7 @@ static void N3DSAUDIO_PlayDevice(_THIS)
 {
     size_t nextbuf;
     size_t sampleLen;
+
     contextLock(this);
 
     nextbuf = this->hidden->nextbuf;
@@ -271,8 +263,6 @@ static SDL_bool N3DSAUDIO_Init(SDL_AudioDriverImpl *impl)
     impl->GetDeviceBuf = N3DSAUDIO_GetDeviceBuf;
     impl->CloseDevice = N3DSAUDIO_CloseDevice;
     impl->ThreadInit = N3DSAUDIO_ThreadInit;
-    impl->LockDevice = N3DSAUD_LockAudio;
-    impl->UnlockDevice = N3DSAUD_UnlockAudio;
     impl->OnlyHasDefaultOutputDevice = SDL_TRUE;
 
     /* Should be possible, but micInit would fail */

--- a/SDL2/src/audio/n3ds/SDL_n3dsaudio.c
+++ b/SDL2/src/audio/n3ds/SDL_n3dsaudio.c
@@ -38,7 +38,7 @@ static SDL_AudioDevice *audio_device;
 static void FreePrivateData(_THIS);
 static int FindAudioFormat(_THIS);
 
-// fully local functions related to the wavebufs / DSP, not the same as the SDL-wide mixer lock
+/* fully local functions related to the wavebufs / DSP, not the same as the SDL-wide mixer lock */
 static SDL_INLINE void contextLock(_THIS)
 {
     LightLock_Lock(&this->hidden->lock);

--- a/SDL2/src/audio/n3ds/SDL_n3dsaudio.h
+++ b/SDL2/src/audio/n3ds/SDL_n3dsaudio.h
@@ -27,7 +27,7 @@
 /* Hidden "this" pointer for the audio functions */
 #define _THIS SDL_AudioDevice *this
 
-#define NUM_BUFFERS 2 /* -- Don't lower this! */
+#define NUM_BUFFERS 3 /* -- Minimum 2! */
 
 struct SDL_PrivateAudioData
 {

--- a/SDL2/src/thread/n3ds/SDL_systhread.c
+++ b/SDL2/src/thread/n3ds/SDL_systhread.c
@@ -27,7 +27,7 @@
 #include "../SDL_systhread.h"
 
 /* N3DS has very limited RAM (128MB), so we put a limit on thread stack size. */
-#define N3DS_THREAD_STACK_SIZE_MAX     (16 * 1024)
+#define N3DS_THREAD_STACK_SIZE_MAX     (128 * 1024)
 #define N3DS_THREAD_STACK_SIZE_DEFAULT (4 * 1024)
 
 #define N3DS_THREAD_PRIORITY_LOW           0x3F /**< Minimum priority */

--- a/SDL2/src/thread/n3ds/SDL_systhread.c
+++ b/SDL2/src/thread/n3ds/SDL_systhread.c
@@ -55,9 +55,10 @@ int SDL_SYS_CreateThread(SDL_Thread *thread)
 
     svcGetThreadPriority(&priority, CUR_THREAD_HANDLE);
 
-    // hack to put mixer thread on system core
-    if(stack_size == 64 * 1024 && R_SUCCEEDED(APT_SetAppCpuTimeLimit(30)))
-        cpu = 1; // system core
+    /* hack to put mixer thread on system core */
+    if (stack_size == 64 * 1024 && R_SUCCEEDED(APT_SetAppCpuTimeLimit(30))) {
+        cpu = 1;
+    }
 
     thread->handle = threadCreate(ThreadEntry,
                                   thread,

--- a/SDL2/src/thread/n3ds/SDL_systhread.c
+++ b/SDL2/src/thread/n3ds/SDL_systhread.c
@@ -49,15 +49,21 @@ static void ThreadEntry(void *arg)
 
 int SDL_SYS_CreateThread(SDL_Thread *thread)
 {
-    s32 priority;
+    s32 priority = 0x30;
+    int cpu = -1;
     size_t stack_size = GetStackSize(thread->stacksize);
+
     svcGetThreadPriority(&priority, CUR_THREAD_HANDLE);
+
+    // hack to put mixer thread on system core
+    if(stack_size == 64 * 1024 && R_SUCCEEDED(APT_SetAppCpuTimeLimit(30)))
+        cpu = 1; // system core
 
     thread->handle = threadCreate(ThreadEntry,
                                   thread,
                                   stack_size,
                                   priority,
-                                  -1,
+                                  cpu,
                                   false);
 
     if (thread->handle == NULL) {


### PR DESCRIPTION
This PR includes various fixes for the SDL audio driver for 3DS.

Primary: removes the implementation-specific audio device lock/unlock functions, which are broken in current SDL2 versions. That made a confusion between the audio device lock and the software mixer lock, and results in a lot of crashes for applications using MixerX on 3DS.

Secondary: restores @Wohlstand's fix for audio stack overflows on 3DS.

Tertiary: includes a hack to move the mixer thread to the system core (detects mixer thread by requested stack size). That core is only allowed to use 30% of CPU time, and using it slows down filesystem access. However, this allows greater runtime for the application on the main core, resulting in fewer gameplay interruptions.

Additional notes:
- Uses a triple buffer instead of a double buffer by default. This avoids underruns, to allow a smaller buffer size for better application responsiveness (when a client application needs the mixer lock).
- Restores @Wohlstand's fix (lost during an SDL2 merge) to not leave the priority variable uninitialized in a function.